### PR TITLE
#163483766 Implement prices for articles

### DIFF
--- a/src/controllers/ArtsController.js
+++ b/src/controllers/ArtsController.js
@@ -29,7 +29,7 @@ class ArtsController {
       const { id: artistId } = req.verifyUser;
 
       const {
-        title, description, categoryId, media
+        title, description, categoryId, media, price
       } = req.body;
 
       mediaFiles = media;
@@ -58,7 +58,8 @@ class ArtsController {
           description,
           categoryId,
           featuredImg: mediaFilesArray[0].url,
-          status: defaultStatus
+          status: defaultStatus,
+          price
         });
 
       const {
@@ -107,6 +108,7 @@ class ArtsController {
           artDescription,
           artFeaturedImg,
           artCategoryId,
+          price,
           visited,
           followersNotified
         }
@@ -160,7 +162,7 @@ class ArtsController {
       }
 
       const {
-        title, description, categoryId, media
+        title, description, categoryId, media, price
       } = req.body;
 
       featuredImgUpdate = artToUpdate.dataValues.featuredImg;
@@ -193,6 +195,7 @@ class ArtsController {
         description,
         categoryId,
         featuredImg: featuredImgUpdate,
+        price
       });
 
       const response = new Response(

--- a/src/middlewares/ArticleValidator.js
+++ b/src/middlewares/ArticleValidator.js
@@ -19,6 +19,7 @@ class ArticleValidator {
     req.check('categoryId', 'Category is required & numeric').isNumeric();
     req.check('description', 'Description should be longer').trim().notEmpty()
       .isLength({ min: 15 });
+    req.check('price', 'Price is required & numeric').isNumeric();
 
     const errors = req.validationErrors();
     const validationErrors = [];

--- a/test/mocks/testData.js
+++ b/test/mocks/testData.js
@@ -149,6 +149,7 @@ const artDetails = {
     title: 'Syntax Podcasts',
     description: 'The Syntax Podcasts isn\'t suitable for all ages',
     categoryId: 1,
+    price: 1500.00,
     media: `[{"url":
     "https://farm3.staticflickr.com/2817/33968464326_a6f9cbc754_k",
     "extension":"jpg"}, 
@@ -161,6 +162,7 @@ const artDetails = {
     slug: 'cirrhosis-of-the-sky',
     description: 'The Syntax Podcasts isn\'t suitable for all ages',
     categoryId: 1,
+    price: 1500.00,
     media: '[{"url":'
       + '"https://images.pexels.com/photos/1047540/pexels-photo-1047540.jpeg",'
       + '"extension":"jpg"},'
@@ -172,6 +174,7 @@ const artDetails = {
     title: '',
     description: 'The Syntax Podcasts isn\'t suitable for all ages',
     categoryId: 1,
+    price: 1500.00,
     media: '[{"url":'
       + '"https://farm3.staticflickr.com/2817/33968464326_a6f9cbc754_k",'
       + '"extension":"jpg"},'
@@ -183,12 +186,14 @@ const artDetails = {
     title: 'Cirrhosis of the Sky',
     description: 'The Syntax Podcasts isn\'t suitable for all ages',
     categoryId: 1,
+    price: 1500.00,
   },
   invalidUpdatedArticle: {
     title: 'Cirrhosis of the Sky',
     slug: 'cirrhosis-of-the-sky',
     description: 'The ',
     categoryId: 100,
+    price: 1500.00,
     media: '[{"url":'
       + '"https://farm3.staticflickr.com/2817/33968464326_a6f9cbc754_k",'
       + '"extension":"jpg"},'
@@ -202,6 +207,7 @@ const artDetails = {
     description: 'To prepare your one sentence, I suggest making a list of all'
       + ' the things you are and do (it may feel silly, ',
     categoryId: 1000,
+    price: 1500.00,
     media: '[{"url":'
       + '"https://farm3.staticflickr.com/2817/33968464326_a6f9cbc754_k",'
       + '"extension":"jpg"},'


### PR DESCRIPTION
#### What does this PR do?
Ensure all articles have price tags

#### Description of Task to be completed?
All articles should have price tags

#### How should this be manually tested?
After installation of dependencies, run `sequelize db:migrate` to update databases.
Then try creating an article with price field(which must be a decimal figure with 2 d.p.).
Example:

`POST > http://localhost:9001/api/v1/arts` VALUES:
```
title:Cirrhosis of the Sky,
description:Cirrhosis of the Sky, The Syntax Podcasts isn't suitable for all ages,
categoryId:1,
price:5000.00,
media:[{"url":"https://farm3.staticflickr.com/2817/33968464326_a6f9cbc754_k","extension":"jpg"},   {"url":"https://images.pexels.com/photos/1047540/pexels-photo-1047540.jpeg?dl&fit=crop&crop=entropy&w=1280&h=853","extension":"jpeg"}]
```

#### Any background context you want to provide?
Only artists are able to create articles

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/163483766

#### Screenshots (if appropriate)
#### Questions: